### PR TITLE
Update to ubuntu.md

### DIFF
--- a/doc/development/ubuntu.md
+++ b/doc/development/ubuntu.md
@@ -47,6 +47,13 @@ sudo apt-get install python-wxgtk3.0
 sudo apt-get remove python-opencv
 sudo apt-get autoremove
 ```
+*NOTE*: Before adding the ppa:bqlabs/horus, check Debian's /etc/apt/ subdirectory for sources.list.d
+If it exists, the proper command will become "sudo add-apt-repository -y ppa:bqlabs/horus"
+Edit the /etc/apt/sources.list.d/bqlabs-horus-jessie.list file to contain:
+deb http://ppa.launchpad.net/bqlabs/horus/ubuntu trusty main
+# deb-src http://ppa.launchpad.net/bqlabs/horus/ubuntu trusty main
+
+save the edits, and continue with sudo apt-get update
 
 ```bash
 sudo add-apt-repository ppa:bqlabs/horus


### PR DESCRIPTION
In Debian 8.x (32 Bit) /etc/apt/sources.list.d exists, and the sudo add-apt-repository ppa:bqlabs/horus command will execute,
but doesn't create the file, and gives no error.  The only way to get the file built is to execute the command with the -y switch
to assume "yes".  Then, the newly created file "bqlabs-horus-jessie.list" needs to be edited to point to the "trusty" repo, so the
PPA GPG key is automatically imported.

REF:  http://www.webupd8.org/2014/10/how-to-add-launchpad-ppas-in-debian-via.html

THANKS.

Larry Kraemer